### PR TITLE
Contact API + UI polish, sitemap, and content updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@
 # misc
 .DS_Store
 *.pem
-.vscode
+.vscode/
 
 # debug
 npm-debug.log*
@@ -39,6 +39,9 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# Warp
+.warp/
 
 # typescript
 *.tsbuildinfo

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+const ContactSchema = z.object({
+  firstname: z.string().min(1),
+  lastname: z.string().min(1),
+  email: z.string().email(),
+  subject: z.string().min(1),
+  message: z.string().min(1),
+  phoneNumber: z.string().optional(),
+  // Honeypot (should stay empty)
+  company: z.string().optional().transform((v) => v ?? ''),
+})
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: Request) {
+  try {
+    const json = await req.json().catch(() => ({}))
+    const parsed = ContactSchema.safeParse(json)
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: 'Invalid payload' }, { status: 400 })
+    }
+
+    // Basic spam check: honeypot must be empty
+    if (parsed.data.company && parsed.data.company.trim().length > 0) {
+      return NextResponse.json({ ok: true }, { status: 200 })
+    }
+
+    // For now, log-only (no secrets). Replace with email/SaaS later.
+    console.log('[contact] submission', {
+      firstname: parsed.data.firstname,
+      lastname: parsed.data.lastname,
+      email: parsed.data.email,
+      subject: parsed.data.subject,
+      phoneNumber: parsed.data.phoneNumber,
+    })
+
+    return NextResponse.json({ ok: true }, { status: 200 })
+  } catch (err) {
+    return NextResponse.json({ ok: false, error: 'Unexpected error' }, { status: 500 })
+  }
+}

--- a/app/data.ts
+++ b/app/data.ts
@@ -1,6 +1,7 @@
 export type WorkExperience = {
   company: string
   title: string
+  subtitle?: string
   start: string
   end: string
   link: string
@@ -35,22 +36,38 @@ export const PROJECTS: Project[] = [
 // Todo: get from Github gist?
 export const WORK_EXPERIENCE: WorkExperience[] = [
   {
+    id: 'janus-1',
     company: 'Janus Health',
-    title: 'Software Engineer II',
-    start: 'Nov 2022',
-    end: 'Apr 2025',
-    link: 'https://janus-ai.com/',
-    id: 'work-1',
+    title: 'Software Engineer 2',
+    subtitle: 'Automations',
+    start: '01/2024',
+    end: '04/2025',
+    link: 'https://www.janus-ai.com',
     highlights: [
       'Built core backend infrastructure for a new product initiative, including a type-safe TypeScript SDK with Zod validation, RESTful API endpoints, and a PostgreSQL database layer using Sequelize ORM',
       'Developed and launched user interfaces for new features and product expansions across multiple core products, utilizing Angular and TypeScript for the frontend and Node.js for backend services',
     ],
   },
   {
+    id: 'janus-2',
+    company: 'Janus Health',
+    title: 'Software Engineer 2',
+    subtitle: 'Document Processing',
+    start: '11/2022',
+    end: '04/2024',
+    link: 'https://www.janus-ai.com/',
+    highlights: [
+      'Aided in multiple efforts to scale the document processing pipeline – including a major database split and deprecating and replacing legacy data models – ultimately resulting in a 10-fold increase in capacity',
+      'Improved system resilience and reliability of the document processing pipeline through strategic implementation of job re-queuing, comprehensive status monitoring, and robust error handling',
+    ],
+  },
+
+  {
     company: 'Walker Macy',
     title: 'Designer',
-    start: 'Nov 2017',
-    end: 'Jul 2021',
+    subtitle: 'Landscape Architecture',
+    start: '11/2017',
+    end: '07/2021',
     link: 'https://walkermacy.com/',
     highlights: [
       'Collaborated frequently within multidisciplinary teams of engineers, architects, and nontechnical stakeholders, often bridging across technical gaps to ensure alignment, and translate high-level concepts into construction-ready specifications for design solutions in a fast-paced, deadline-driven environment',

--- a/app/footer.tsx
+++ b/app/footer.tsx
@@ -4,26 +4,26 @@ import ThemeSwitch from '@/components/theme-switch'
 
 export function Footer() {
   return (
-    <footer className="text-secondary border-muted border-t px-0 py-8 dark:border-zinc-800">
-      <div className="relative flex min-w-full items-center justify-end gap-6 text-xs tracking-tight">
-        <div className="absolute left-0 text-xs">
+    <footer className="text-muted border-faint border-t px-0 py-8 dark:border-zinc-800">
+      <div className="relative flex min-w-full items-center justify-start gap-6 text-xs tracking-tight">
+        <div className="absolute right-0 text-xs">
           <ThemeSwitch />
-        </div>
-
-        <div className="inline-flex content-center items-center gap-1">
-          <MapPinIcon size={12} />
-          <span>Brooklyn, NY</span>
         </div>
 
         <a
           href="https://github.com/leesimonh"
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center justify-end gap-0.5"
+          className="text-secondary flex items-center justify-start gap-1 leading-0 decoration-transparent"
         >
           <CopyrightIcon size={12} />
           2025 Simon H Lee
         </a>
+
+        <div className="flex items-center justify-start gap-1 leading-0 decoration-transparent">
+          <MapPinIcon size={12} />
+          <span>Brooklyn, NY</span>
+        </div>
       </div>
 
       <div className="hidden min-w-full grid-cols-12 place-items-end gap-8 text-xs tracking-tight">

--- a/app/globals.css
+++ b/app/globals.css
@@ -43,34 +43,6 @@
   --font-mono: var(--font-geist-mono);
   /* Specialized Fonts */
   --font-heading: var(--font-geist);
-
-  /*#region MARK: Custom Colors */
-  --color-lilac: oklch(0.785 0.098 294.3);
-  /*#endregion Custom Colors */
-}
-
-@layer utilities {
-  .magic-pattern-wavy {
-    /* background-color:; */
-    opacity: 0.1;
-    background-image:
-      repeating-radial-gradient(circle at 0 0, transparent 0, var(--color-background) 8px),
-      repeating-linear-gradient(var(--color-muted), var(--color-muted));
-  }
-
-  .magic-pattern-circles {
-    background-color: #d9dee5;
-    opacity: 0.1;
-    background-image:
-      radial-gradient(circle at center center, var(--color-rose-700), var(--color-rose-100)),
-      repeating-radial-gradient(
-        circle at center center,
-        var(--color-rose-700) var(--color-rose-700) 8px,
-        transparent 16px,
-        transparent 8px
-      );
-    background-blend-mode: multiply;
-  }
 }
 
 @layer base {
@@ -120,15 +92,15 @@
     }
   }
 
-  :is(a, .link) {
-    @apply text-link cursor-pointer font-medium transition-colors duration-200 ease-in-out;
+  :where(a, .link) {
+    @apply text-link cursor-pointer underline decoration-zinc-500 underline-offset-2 transition-colors duration-200 ease-in-out;
 
     &:hover {
-      @apply text-link-hover;
+      @apply text-link-hover decoration-link-hover;
     }
   }
 
-  .btn-link {
+  :where(.btn-link) {
     @apply text-link cursor-pointer font-medium transition-colors duration-200 ease-in-out;
 
     &:hover {

--- a/app/header.tsx
+++ b/app/header.tsx
@@ -2,11 +2,12 @@
 
 import ThemeSwitch from '@/components/theme-switch'
 import { TextEffect } from '@/components/ui/text-effect'
+import { TextLoop } from '@/components/ui/text-loop'
 import { motion } from 'motion/react'
 
 export function Header() {
   return (
-    <header className="text-body-primary relative top-0 right-0 left-0 flex w-full">
+    <header className="text-primary relative top-0 right-0 left-0 flex w-full">
       <span className="absolute top-0 right-0 z-50">
         <ThemeSwitch />
       </span>
@@ -24,25 +25,29 @@ export function Header() {
         }}
       >
         <TextEffect
-          as="span"
-          preset="slide"
-          per="char"
-          className="mb-2 inline max-w-fit font-sans leading-none tracking-tighter"
-          delay={0.2}
-        >
-          Hey there! I'm
-        </TextEffect>
-
-        <TextEffect
-          as="code"
+          as="h1"
           preset="fade-in-blur"
           per="char"
-          delay={0.3}
-          className="font-sans text-2xl leading-none font-bold tracking-tighter"
-          speedSegment={0.6}
+          delay={0.2}
+          className="text-2xl leading-none font-bold tracking-tighter"
         >
           Simon H Lee
         </TextEffect>
+
+        <TextLoop interval={3.5} className="leading-loose italic">
+          {['Software Engineer', 'Urbanist', 'Creative'].map((nickname) => (
+            <TextEffect
+              as="span"
+              preset="fade-in-blur"
+              per="char"
+              delay={0.3}
+              speedSegment={0.6}
+              key={nickname}
+            >
+              {nickname}
+            </TextEffect>
+          ))}
+        </TextLoop>
       </motion.div>
     </header>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { ContactFormInline } from '@/components/contact-form-inline'
 import { AnimatedBackground } from '@/components/ui/animated-background'
 import { Magnetic } from '@/components/ui/magnetic'
 import ExperiencesTimeline from '@/components/vertical-timeline'
@@ -6,7 +7,6 @@ import { motion } from 'motion/react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { BLOG_POSTS as FALLBACK_BLOG_POSTS, SOCIAL_LINKS, WORK_EXPERIENCE } from './data'
-import { ContactFormInline } from '@/components/contact-form-inline'
 
 const VARIANTS_CONTAINER = {
   hidden: { opacity: 0 },
@@ -27,46 +27,12 @@ const TRANSITION_SECTION = {
   duration: 0.3,
 }
 
-// function SocialMediaVideo(props: { url: string; children: any }) {
-//   return (
-//     <MorphingDialog
-//       transition={{
-//         type: 'spring',
-//         bounce: 0,
-//         duration: 0.3,
-//       }}
-//     >
-//       <MorphingDialogTrigger>{props.children}</MorphingDialogTrigger>
-//       <MorphingDialogContainer>
-//         <MorphingDialogContent className="relative aspect-auto rounded-2xl bg-white p-1 ring-1 ring-zinc-200/50 ring-inset dark:bg-black dark:ring-zinc-800/50">
-//           <div style={{ display: 'flex', justifyContent: 'center' }}>
-//             <InstagramEmbed url={props.url} width={328} />
-//           </div>
-//         </MorphingDialogContent>
-//         <MorphingDialogClose
-//           className="fixed top-6 right-6 h-fit w-fit rounded-full bg-white p-1"
-//           variants={{
-//             initial: { opacity: 0 },
-//             animate: {
-//               opacity: 1,
-//               transition: { delay: 0.3, duration: 0.1 },
-//             },
-//             exit: { opacity: 0, transition: { duration: 0 } },
-//           }}
-//         >
-//           <XIcon className="h-5 w-5 text-zinc-500" />
-//         </MorphingDialogClose>
-//       </MorphingDialogContainer>
-//     </MorphingDialog>
-//   )
-// }
-
 function MagneticSocialLink({ children, link }: { children: React.ReactNode; link: string }) {
   return (
     <Magnetic springOptions={{ bounce: 0 }} intensity={0.3}>
       <a
         href={link}
-        className="group bg-faint hover:bg-primary text-primary relative inline-flex shrink-0 items-center gap-1 rounded-full px-3 py-1 font-mono text-sm tracking-tight transition-all duration-300 hover:font-bold dark:not-hover:bg-zinc-800/60 dark:hover:bg-zinc-100"
+        className="group bg-faint hover:bg-primary text-primary relative inline-flex shrink-0 items-center gap-1 rounded-full px-3 py-1 font-mono text-sm tracking-tight decoration-transparent transition-all duration-300 hover:font-bold dark:not-hover:bg-zinc-800/60 dark:hover:bg-zinc-100"
       >
         <span className="transition-color text-primary group-hover:text-on-primary dark:group-hover:text-on-primary z-10 inline-flex items-center gap-1 duration-200">
           {children}
@@ -104,6 +70,9 @@ export default function Personal() {
   )
 
   useEffect(() => {
+    /**
+     * API endpoint to get stuff at /blog
+     */
     fetch('/api/blogposts')
       .then((r) => (r.ok ? r.json() : []))
       .then((data: { title: string; description?: string; link: string; uid: string }[]) => {
@@ -114,7 +83,7 @@ export default function Personal() {
 
   return (
     <motion.main
-      className="my-8 flex max-w-full flex-col gap-16"
+      className="my-12 flex max-w-full flex-col gap-24"
       variants={VARIANTS_CONTAINER}
       initial="hidden"
       animate="visible"
@@ -126,43 +95,38 @@ export default function Personal() {
         className="flex-1 space-y-8"
       >
         {/* <h2 className="font-heading mb-4 text-lg">About</h2> */}
-        <div className="text-body-secondary flex flex-1 flex-col gap-4 text-sm">
-          <p>
-            I used to consider myself a{' '}
-            <code className="font-mono font-bold tracking-tighter">software engineer</code>,<br />
-            but the reality is that I just like creating things and solving problems.
-          </p>
-          <p className="text-pretty">
-            I'm a co-creater of{' '}
-            <a
-              href="https://github.com/oslabs-beta/Svve11"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="link"
-            >
-              svve11
-            </a>
-            {', '}
-            an open-source library of{' '}
-            <a
-              href="https://github.com/oslabs-beta/Svve11"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="link"
-            >
-              Svelte
-            </a>{' '}
-            components focused on web accessibility.
-          </p>
-          <p>
-            In my spare time, I climb.
-            <br />
-            <span className="text-secondary text-xs italic">
-              I do other things too... (when I'm too tired to climb)
-            </span>
-          </p>
-        </div>
+
+        <p>
+          Hi there! I'm Simon.
+          <br />
+          I like making things, and I like solving problems.
+          <br />
+          Bonus points if the problem requires making things.
+        </p>
         {/* MARK: Social Chips/Hovers/Cards */}
+
+        <div>
+          <span>
+            These days I spend most of my free time{' '}
+            <a href="https://instagram.com/crimpwimp" target="_blank" rel="noopener noreferrer">
+              climbing
+            </a>
+            ,<br />
+            but other things I enjoy include:
+          </span>
+          <div>
+            <ul className="mt-2 list-inside list-disc">
+              <li>noodling around on the piano and guitar</li>
+              <li>$1 slices</li>
+              <li>
+                <a href="https://vsco.co/simonhl/gallery">snapping photos</a>
+              </li>
+              <li>
+                <em>Channel Orange</em> by Frank Ocean
+              </li>
+            </ul>
+          </div>
+        </div>
       </motion.section>
 
       {/* MARK: Work Experience */}
@@ -191,7 +155,7 @@ export default function Personal() {
               // Expanding Corner (experiment)
               <Link
                 key={post.uid}
-                className="group before:bg-primary before bg-background border-faint dark:border-faint relative z-0 -mx-4 mb-4 w-full cursor-pointer overflow-hidden rounded-xl border px-4 py-3 before:absolute before:top-0 before:left-0 before:z-[-1] before:h-2 before:w-2 before:rounded-full before:opacity-0 before:transition-all before:duration-[400ms] before:ease-out hover:before:scale-[150] hover:before:opacity-100 dark:bg-zinc-800/30"
+                className="group before:bg-primary before bg-background border-faint dark:border-faint relative z-0 mb-4 w-full cursor-pointer overflow-hidden rounded-lg border px-4 py-3 decoration-transparent before:absolute before:top-0 before:left-0 before:z-[-1] before:h-2 before:w-2 before:rounded-full before:opacity-0 before:transition-all before:duration-[400ms] before:ease-out hover:decoration-transparent hover:before:scale-[150] hover:before:opacity-100 dark:bg-zinc-800/30"
                 href={post.link}
                 data-id={post.uid}
               >
@@ -200,7 +164,7 @@ export default function Personal() {
                     {post.title}
                   </h4>
 
-                  <p className="text-secondary group-hover:text-on-primary mt-1 text-sm font-normal transition-colors duration-500 ease-out group-hover:font-normal">
+                  <p className="text-secondary group-hover:text-on-primary mt-1 text-sm font-normal transition-colors delay-100 duration-500 ease-out group-hover:font-normal">
                     {post.description}
                   </p>
                 </div>
@@ -234,7 +198,7 @@ export default function Personal() {
           <h3 className="font-heading sr-only hidden" aria-hidden="true" aria-label="socials">
             Socials
           </h3>
-          <div className="flex flex-wrap gap-1">
+          <div className="flex flex-wrap gap-4">
             {SOCIAL_LINKS.map((link) => (
               <MagneticSocialLink key={link.label} link={link.link}>
                 {link.label}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,36 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+
+const SITE_URL = 'https://simonhlee.vercel.app'
+// const SITE_URL = 'http://localhost:3000'
+
+async function getNoteSlugs(dir: string) {
+  const entries = await fs.readdir(dir, {
+    recursive: true,
+    withFileTypes: true,
+  })
+  return entries
+    .filter((entry) => entry.isFile() && entry.name === 'page.mdx')
+    .map((entry) => {
+      const relativePath = path.relative(dir, path.join(entry.parentPath, entry.name))
+      return path.dirname(relativePath)
+    })
+    .map((slug) => slug.replace(/\\/g, '/'))
+}
+
+export default async function sitemap() {
+  const notesDirectory = path.join(process.cwd(), 'app', 'blog')
+  const slugs = await getNoteSlugs(notesDirectory)
+
+  const notes = slugs.map((slug) => ({
+    url: `${SITE_URL}/blog/${slug}`,
+    lastModified: new Date().toISOString(),
+  }))
+
+  const routes = ['', '/work'].map((route) => ({
+    url: `${SITE_URL}${route}`,
+    lastModified: new Date().toISOString(),
+  }))
+
+  return [...routes, ...notes]
+}

--- a/components/contact-form-inline.tsx
+++ b/components/contact-form-inline.tsx
@@ -12,6 +12,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { MailIcon } from 'lucide-react'
 import { useForm, type SubmitHandler } from 'react-hook-form'
 import { z } from 'zod'
 
@@ -43,13 +44,22 @@ function ContactFormInline() {
     criteriaMode: 'all',
   })
 
-  const onSubmit: SubmitHandler<ContactForm> = (data) => {
-    // if (!validateForm()) {
-    //   return
-    // }
-    // Todo: Handle form submission here
-    // TODO: handle successful submission without logging sensitive data
-    alert('Form submitted')
+  const onSubmit: SubmitHandler<ContactForm> = async (data) => {
+    // Honeypot field (invisible); bots often fill it
+    const payload = { ...data, company: '' }
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (!res.ok) throw new Error('Request failed')
+      // Simple UX: reset on success
+      contactForm.reset()
+      alert('Thanks! Your message was sent.')
+    } catch (e) {
+      alert('Sorry, there was a problem sending your message.')
+    }
   }
 
   return (
@@ -193,8 +203,12 @@ function ContactFormInline() {
           )}
         />
 
-        <Button type="submit" className="w-full cursor-pointer">
-          Send message
+        <Button
+          variant={'outline'}
+          type="submit"
+          className="hover:text-on-primary border-muted cursor-pointer"
+        >
+          <MailIcon /> Send message
         </Button>
       </form>
     </Form>

--- a/components/theme-switch.tsx
+++ b/components/theme-switch.tsx
@@ -8,17 +8,17 @@ const THEMES_OPTIONS = [
   {
     label: 'System',
     id: 'system',
-    icon: <MonitorIcon className="h-3 w-3" />,
+    icon: <MonitorIcon className="h-3.5 w-3.5" />,
   },
   {
     label: 'Light',
     id: 'light',
-    icon: <SunIcon className="h-3 w-3" />,
+    icon: <SunIcon className="h-3.5 w-3.5" />,
   },
   {
     label: 'Dark',
     id: 'dark',
-    icon: <MoonIcon className="h-3 w-3" />,
+    icon: <MoonIcon className="h-3.5 w-3.5" />,
   },
 ]
 
@@ -53,7 +53,7 @@ export default function ThemeSwitch() {
         return (
           <button
             key={t.id}
-            className={`hover:text-primary-hover dark:data-[checked=true]:text-accent transition-all] inline-flex cursor-pointer items-center justify-center rounded-full p-0.5 duration-300 focus-visible:outline-2 data-[checked=true]:text-black ${theme === t.id ? 'text-primary border-faint border shadow-sm dark:border-zinc-700/50 dark:bg-zinc-800/90 dark:shadow-none' : 'text-muted'}`}
+            className={`hover:text-primary-hover dark:data-[checked=true]:text-accent transition-all] mx-0.5 inline-flex cursor-pointer items-center justify-center rounded-full p-1 duration-300 focus-visible:outline-2 data-[checked=true]:text-black ${theme === t.id ? 'text-primary' : 'text-muted'}`}
             type="button"
             aria-label={`Switch to ${t.label} theme`}
             data-id={t.id}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -7,7 +7,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       type={type}
       data-slot="input"
       className={cn(
-        'file:text-foreground placeholder:text-muted-foreground dark:bg-faint/30 border-faint dark:border-muted flex w-full min-w-0 rounded-md border bg-transparent px-3 py-1.5 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'file:text-foreground placeholder:text-muted-foreground border-faint dark:border-muted flex w-full min-w-0 rounded-md border bg-transparent px-3 py-1.5 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[1px]',
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         className

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentPropsWithoutRef<'texta
     <textarea
       data-slot="textarea"
       className={cn(
-        'border-faint placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-error dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-1.5 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[1px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'border-faint placeholder:text-muted-foreground dark:bg-faint/30 focus-visible:border-ring focus-visible:ring-ring/50 dark:border-muted aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-error dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-1.5 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[1px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         className
       )}
       {...props}

--- a/components/vertical-timeline.tsx
+++ b/components/vertical-timeline.tsx
@@ -13,11 +13,11 @@ import { AsteriskIcon } from 'lucide-react'
 
 export default function ExperiencesTimeline(props: { experiences: WorkExperience[] }) {
   return (
-    <div className="h-full w-full max-w-[48ch]">
+    <div className="h-full w-full max-w-[50ch]">
       <Timeline defaultValue={props.experiences.length}>
-        {props.experiences.map((item, idx) => (
+        {props.experiences.map((job, idx) => (
           <TimelineItem
-            key={item.id}
+            key={job.id}
             step={idx + 1}
             className="text-primary group-data-[orientation=vertical]/timeline:ms-10"
           >
@@ -27,28 +27,33 @@ export default function ExperiencesTimeline(props: { experiences: WorkExperience
               <TimelineTitle>
                 <div className="flex w-full items-baseline justify-between">
                   {/* MARK: Job Title */}
-                  <span className="text-base font-medium">{item.title}</span>
+                  <span className="text-base font-medium">
+                    {job.title}
+                    {job.subtitle && (
+                      <span className="text-secondary text-sm font-normal">
+                        {', '}
+                        {job.subtitle}
+                      </span>
+                    )}
+                  </span>
 
                   {/* MARK: Job -> Dates */}
                   <TimelineDate>
-                    <div
-                      className="flex text-sm font-normal text-zinc-500"
-                      style={{ wordSpacing: '-0.02em' }}
-                    >
-                      {item.start} - {item.end}
+                    <div className="text-muted text-sm font-normal tracking-tighter">
+                      {job.start} - {job.end}
                     </div>
                   </TimelineDate>
                 </div>
 
                 {/* MARK: Company Name */}
                 <a
-                  href={item.link}
+                  href={job.link}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="group relative inline-block hover:bg-transparent"
                 >
-                  <span className="group text-secondary/90 hover:text-secondary-hover/90 relative inline-flex shrink-1 items-center gap-0.5 text-base leading-snug font-normal transition-colors duration-300 ease-in-out">
-                    {item.company}{' '}
+                  <span className="group text-secondary hover:text-link-hover relative inline-flex shrink-1 items-center gap-0.5 text-base leading-snug font-normal transition-colors duration-300 ease-in-out">
+                    {job.company}{' '}
                     <svg
                       width="15"
                       height="15"
@@ -63,24 +68,24 @@ export default function ExperiencesTimeline(props: { experiences: WorkExperience
                         clipRule="evenodd"
                       ></path>
                     </svg>
-                    <span className="bg-accent-hover absolute bottom-0.5 left-0 block h-px w-full max-w-0 transition-all duration-300 group-hover:max-w-full"></span>
+                    <span className="bg-link-hover absolute bottom-0.5 left-0 block h-px w-full max-w-0 transition-all duration-300 group-hover:max-w-full"></span>
                   </span>
                 </a>
               </TimelineTitle>
 
               <TimelineIndicator className="flex size-8 items-center justify-center group-data-completed/timeline-item:border-0 group-data-[orientation=vertical]/timeline:-left-8">
-                <AsteriskIcon className="group-not-data-completed/timeline-item:hidden" size={20} />
+                <AsteriskIcon className="group-not-data-completed/timeline-item:hidden" />
               </TimelineIndicator>
             </TimelineHeader>
 
             {/* MARK: Job Description */}
             <TimelineContent>
               <div className="text-body-secondary flex-col leading-normal tracking-normal">
-                {item.highlights && item.highlights.length > 0 && (
+                {job.highlights && job.highlights.length > 0 && (
                   <ul className="mt-2 list-none">
-                    {item.highlights.map((highlight, idx) => (
+                    {job.highlights.map((highlight, idx) => (
                       <li
-                        key={`${item.id}-highlight-${idx}`}
+                        key={`${job.id}-highlight-${idx}`}
                         className="mb-4 font-sans text-sm leading-normal text-pretty"
                       >
                         {highlight}

--- a/lib/styles/theme.css
+++ b/lib/styles/theme.css
@@ -25,7 +25,7 @@
   --color-accent: var(--color-zinc-800);
   --color-accent-hover: var(--color-black);
 
-  --color-link: var(--color-primary);
+  --color-link: var(--color-secondary);
   --color-link-hover: var(--color-primary-hover);
 
   --color-error: var(--color-red-500);


### PR DESCRIPTION
# Summary

Wires the inline contact form to a simple API endpoint, refines site styling, and adds a sitemap route.

## Changes

**Contact**

- Add /api/contact endpoint with Zod validation and honeypot spam check (log-only handler for now)
- Wire ContactFormInline to POST to /api/contact; reset on success with simple success/error feedback

**UI/Theme**

- Polish theme tokens and Tailwind v4 globals
- Refine header/footer styles; tweak ThemeSwitch UX
- Standardize Input/Textarea styles

**Content/Infra**

- Add app/sitemap.ts for dynamic sitemap (includes blog slugs)
- Update app/data.ts and vertical timeline entries
- Ignore .warp/ local docs dir in .gitignore

**Docs**

- Update README with setup, scripts, MDX authoring, styling, deploy